### PR TITLE
Patch 1

### DIFF
--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic
 import Mathlib.Data.Nat.Prime
 
+/-- 自然数が0でも1でもなければ2以上 -/
 lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
   -- 仮定から m = 0 のときは考えなくていい
   cases m; contradiction; rename_i n

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -13,23 +13,40 @@ lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
   -- これは明らか
   simp_arith
 
+/-- n が2以上なら， n を割り切る素数が存在する -/
 lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p ∣ n := by
+  -- n が素数かどうかで場合分けをする
   by_cases np : n.Prime
-  · use n, np
-  induction' n using Nat.strong_induction_on with n ih
-  rw [Nat.prime_def_lt] at np
-  push_neg at np
-  rcases np h with ⟨m, mltn, mdvdn, mne1⟩
-  have : m ≠ 0 := by
-    intro mz
-    rw [mz, zero_dvd_iff] at mdvdn
-    linarith
-  have mgt2 : 2 ≤ m := two_le this mne1
-  by_cases mp : m.Prime
-  · use m, mp
-  . rcases ih m mltn mgt2 mp with ⟨p, pp, pdvd⟩
-    use p, pp
-    apply pdvd.trans mdvdn
+
+  -- n が素数のとき
+  case pos =>
+    -- 素数 p として n 自身を使えばいいので明らか
+    use n, np
+
+  -- n が素数ではないとき
+  case neg =>
+    -- n に関する完全帰納法で示す
+    induction n using Nat.strong_induction_on with
+
+    -- 帰納法の仮定を ih とする
+    | h n ih =>
+      -- n が素数でないということを， 素数の定義に従って書き直すと,
+      rw [Nat.prime_def_lt] at np
+      push_neg at np
+      specialize np h
+
+      -- n には自明でない約数 m が存在することがわかる．
+      obtain ⟨m, mltn, mdvdn, mne1⟩ := np
+      have : m ≠ 0 := by
+        intro mz
+        rw [mz, zero_dvd_iff] at mdvdn
+        linarith
+      have mgt2 : 2 ≤ m := two_le this mne1
+      by_cases mp : m.Prime
+      · use m, mp
+      . rcases ih m mltn mgt2 mp with ⟨p, pp, pdvd⟩
+        use p, pp
+        apply pdvd.trans mdvdn
 
 theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   intro n

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -58,23 +58,47 @@ lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p �
     use p, pp
     trans m <;> assumption
 
+/-- 素数は無限に存在する． 具体的には，任意の自然数 n に対して， 
+n よりも大きな素数 p が存在する． -/
 theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
+  -- 任意に自然数 n が与えられたとする
   intro n
 
-  have : 2 ≤ Nat.factorial (n + 1) + 1 := by
-    have : 1 ≤ Nat.factorial (n + 1) := calc
-      1 ≤ n + 1 := by linarith
-      _ ≤ Nat.factorial (n + 1) := by apply Nat.self_le_factorial
-    linarith
-  rcases exists_prime_factor this with ⟨p, pp, pdvd⟩
-  refine' ⟨p, _, pp⟩
+  -- k = (n + 1)! + 1 とする．ただし ! は階乗を表す.
+  set k := (n + 1).factorial + 1 with kh
+
+  -- このとき k はもちろん 2 以上であるので，
+  have : 2 ≤ k := calc
+    2 ≤ n + 1 + 1 := by simp_arith 
+    _ ≤ (n + 1).factorial + 1 := by gcongr; apply Nat.self_le_factorial
+    _ = k := by rw [← kh]
+
+  -- 先に示した定理により， k には素因数 p が存在する.
+  obtain ⟨p, pp, pdvd⟩ := exists_prime_factor this
+  clear this
+
+  -- この p が望みの性質を満たすことを示そう．
+  refine ⟨p, ?_, pp⟩
+
+  -- p > n を示せばよい.
   show p > n
-  by_contra ple
-  push_neg  at ple
-  have : p ∣ Nat.factorial (n + 1) := by
-    apply Nat.dvd_factorial (pp.pos) (by linarith)
-  have : p ∣ 1 := by
+
+  -- 仮に p ≤ n だったとする．
+  by_contra! ple
+
+  -- このとき p は (n + 1)! の約数になる.
+  have : p ∣ (n + 1).factorial := by
+    -- なぜなら， (n + 1)! = 1 × 2 × ... × (n + 1) の中に p が含まれるからだ．
+    exact Nat.dvd_factorial pp.pos (show p ≤ n + 1 from by linarith)
+  
+  -- したがって p は 1 を割り切るということになる.
+  replace : p ∣ 1 := by
+    -- なぜなら， p は k の約数だったから (n + 1)! + 1 の約数でもあって
+    rw [kh] at pdvd
+
+    -- p の倍数同士の差をとっても p の倍数だからだ．
     convert Nat.dvd_sub' pdvd this
     simp
-  show False
-  aesop
+
+  -- これは p が素数であるという仮定に反しており，矛盾である．
+  simp_all

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -3,8 +3,8 @@ import Mathlib.Tactic
 /-- 自然数が0でも1でもなければ2以上 -/
 lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
   -- 仮定から m = 0, 1 のときは考えなくていい
-  repeat
-    cases m; contradiction; rename_i m
+  let .succ m := m
+  let .succ m := m
   
   -- 自然数 0 ≤ m に対して 2 ≤ m + 2 を示せばよい
   simp_all; show 2 ≤ m + 2

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -13,6 +13,8 @@ lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
   -- これは明らか
   simp_arith
 
+  done
+
 /-- n が2以上なら， n を割り切る素数が存在する -/
 lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p ∣ n := by
   -- n が素数かどうかで場合分けをする
@@ -58,6 +60,12 @@ lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p �
     use p, pp
     trans m <;> assumption
 
+    done
+
+-- 階乗の記法を導入する
+-- これは Boolean の否定と競合しそうなので，普段は使わないほうが良いかもしれない
+postfix:100 "!" => Nat.factorial
+
 /-- 素数は無限に存在する． 具体的には，任意の自然数 n に対して， 
 n よりも大きな素数 p が存在する． -/
 theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
@@ -65,12 +73,12 @@ theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   intro n
 
   -- k = (n + 1)! + 1 とする．ただし ! は階乗を表す.
-  set k := (n + 1).factorial + 1 with kh
+  set k := (n + 1)! + 1 with kh
 
   -- このとき k はもちろん 2 以上であるので，
   have ge2 : 2 ≤ k := calc
     2 ≤ n + 1 + 1 := by simp_arith 
-    _ ≤ (n + 1).factorial + 1 := by gcongr; apply Nat.self_le_factorial
+    _ ≤ (n + 1)! + 1 := by gcongr; apply Nat.self_le_factorial
     _ = k := by rw [← kh]
 
   -- 先に示した定理により， k には素因数 p が存在する.
@@ -86,7 +94,7 @@ theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   by_contra! ple
 
   -- このとき p は (n + 1)! の約数になる.
-  have : p ∣ (n + 1).factorial := by
+  have : p ∣ (n + 1)! := by
     -- なぜなら， (n + 1)! = 1 × 2 × ... × (n + 1) の中に p が含まれるからだ．
     exact Nat.dvd_factorial pp.pos (show p ≤ n + 1 from by linarith)
   
@@ -100,4 +108,6 @@ theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
     simp
 
   -- これは p が素数であるという仮定に反しており，矛盾である．
-  simp_all
+  aesop
+
+  done

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -3,14 +3,12 @@ import Mathlib.Data.Nat.Prime
 
 /-- 自然数が0でも1でもなければ2以上 -/
 lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
-  -- 仮定から m = 0 のときは考えなくていい
-  cases m; contradiction; rename_i n
+  -- 仮定から m = 0, 1 のときは考えなくていい
+  repeat
+    cases m; contradiction; rename_i m
   
-  -- 仮定から m = 1 のときも考えなくていい
-  cases n; contradiction; rename_i k
-  
-  -- 自然数 0 ≤ k に対して 2 ≤ k + 2 を示せばよい
-  simp_all; show 2 ≤ k + 2
+  -- 自然数 0 ≤ m に対して 2 ≤ m + 2 を示せばよい
+  simp_all; show 2 ≤ m + 2
 
   -- これは明らか
   simp_arith

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -1,5 +1,4 @@
 import Mathlib.Tactic
-import Mathlib.Data.Nat.Prime
 
 /-- 自然数が0でも1でもなければ2以上 -/
 lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -15,21 +15,21 @@ lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
 
 /-- n が2以上なら， n を割り切る素数が存在する -/
 lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p ∣ n := by
-  -- n が素数かどうかで場合分けをする
-  by_cases np : n.Prime
+  -- n に関する完全帰納法で示す.
+  induction n using Nat.strong_induction_on with
 
-  -- n が素数のとき
-  case pos =>
-    -- 素数 p として n 自身を使えばいいので明らか
-    use n, np
+  -- 帰納法の仮定に ih と名前をつけておく.
+  | h n ih =>
+    -- n が素数かどうかで場合分けをする
+    by_cases np : n.Prime
+  
+    -- n が素数のとき
+    case pos =>
+      -- 素数 p として n 自身を使えばいいので明らか.
+      use n, np
 
-  -- n が素数ではないとき
-  case neg =>
-    -- n に関する完全帰納法で示す
-    induction n using Nat.strong_induction_on with
-
-    -- 帰納法の仮定を ih とする
-    | h n ih =>
+    -- n が素数ではないとき
+    case neg =>
       -- n が素数でないということを， 素数の定義に従って書き直すと,
       rw [Nat.prime_def_lt] at np
       push_neg at np
@@ -37,16 +37,31 @@ lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p �
 
       -- n には自明でない約数 m が存在することがわかる．
       obtain ⟨m, mltn, mdvdn, mne1⟩ := np
-      have : m ≠ 0 := by
-        intro mz
+
+      -- ここで特に m は 0 ではない.
+      have mne0 : m ≠ 0 := by
+        -- 仮に m = 0 だとすると,
+        intro (mz : m = 0)
+
+        -- m ∣ n なので n = 0 となる.
         rw [mz, zero_dvd_iff] at mdvdn
-        linarith
-      have mgt2 : 2 ≤ m := two_le this mne1
-      by_cases mp : m.Prime
-      · use m, mp
-      . rcases ih m mltn mgt2 mp with ⟨p, pp, pdvd⟩
-        use p, pp
-        apply pdvd.trans mdvdn
+
+        -- これは 2 ≤ n に矛盾する.
+        simp_all
+
+      -- m は 0 でも 1 でもないので， 先に示したことから 2 以上である．
+      have mgt2 : 2 ≤ m := two_le mne0 mne1
+      clear mne1 mne0 h -- もう使わない結果を消しておく
+
+      -- 帰納法の仮定から m には素因数が存在するので，
+      specialize ih m mltn mgt2
+      
+      -- その素因数を p とする.
+      obtain ⟨p, pp, pdvd⟩ := ih
+      
+      -- その素数 p が望みの性質を満たす．
+      use p, pp
+      trans m <;> assumption
 
 theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   intro n

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -2,11 +2,17 @@ import Mathlib.Tactic
 import Mathlib.Data.Nat.Prime
 
 lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
-  cases m; contradiction
-  case succ m =>
-    cases m; contradiction
-    repeat' apply Nat.succ_le_succ
-    apply zero_le
+  -- 仮定から m = 0 のときは考えなくていい
+  cases m; contradiction; rename_i n
+  
+  -- 仮定から m = 1 のときも考えなくていい
+  cases n; contradiction; rename_i k
+  
+  -- 自然数 0 ≤ k に対して 2 ≤ k + 2 を示せばよい
+  simp_all; show 2 ≤ k + 2
+
+  -- これは明らか
+  simp_arith
 
 lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p ∣ n := by
   by_cases np : n.Prime

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -15,53 +15,48 @@ lemma two_le {m : ℕ} (h0 : m ≠ 0) (h1 : m ≠ 1) : 2 ≤ m := by
 
 /-- n が2以上なら， n を割り切る素数が存在する -/
 lemma exists_prime_factor {n : Nat} (h : 2 ≤ n) : ∃ p : Nat, p.Prime ∧ p ∣ n := by
-  -- n に関する完全帰納法で示す.
-  induction n using Nat.strong_induction_on with
+  -- n が素数かどうかで場合分けをする
+  by_cases np : n.Prime
 
-  -- 帰納法の仮定に ih と名前をつけておく.
-  | h n ih =>
-    -- n が素数かどうかで場合分けをする
-    by_cases np : n.Prime
-  
-    -- n が素数のとき
-    case pos =>
-      -- 素数 p として n 自身を使えばいいので明らか.
-      use n, np
+  -- n が素数のとき
+  case pos =>
+    -- 素数 p として n 自身を使えばいいので明らか.
+    use n, np
 
-    -- n が素数ではないとき
-    case neg =>
-      -- n が素数でないということを， 素数の定義に従って書き直すと,
-      rw [Nat.prime_def_lt] at np
-      push_neg at np
-      specialize np h
+  -- n が素数ではないとき
+  case neg =>
+    -- n が素数でないということを， 素数の定義に従って書き直すと,
+    rw [Nat.prime_def_lt] at np
+    push_neg at np
+    specialize np h
 
-      -- n には自明でない約数 m が存在することがわかる．
-      obtain ⟨m, mltn, mdvdn, mne1⟩ := np
+    -- n には自明でない約数 m が存在することがわかる．
+    obtain ⟨m, _mltn, mdvdn, mne1⟩ := np
 
-      -- ここで特に m は 0 ではない.
-      have mne0 : m ≠ 0 := by
-        -- 仮に m = 0 だとすると,
-        intro (mz : m = 0)
+    -- ここで特に m は 0 ではない.
+    have mne0 : m ≠ 0 := by
+      -- 仮に m = 0 だとすると,
+      intro (mz : m = 0)
 
-        -- m ∣ n なので n = 0 となる.
-        rw [mz, zero_dvd_iff] at mdvdn
+      -- m ∣ n なので n = 0 となる.
+      rw [mz, zero_dvd_iff] at mdvdn
 
-        -- これは 2 ≤ n に矛盾する.
-        simp_all
+      -- これは 2 ≤ n に矛盾する.
+      simp_all
 
-      -- m は 0 でも 1 でもないので， 先に示したことから 2 以上である．
-      have mgt2 : 2 ≤ m := two_le mne0 mne1
-      clear mne1 mne0 h -- もう使わない結果を消しておく
+    -- m は 0 でも 1 でもないので， 先に示したことから 2 以上である．
+    have mgt2 : 2 ≤ m := two_le mne0 mne1
+    clear mne1 mne0 h -- もう使わない結果を消しておく
 
-      -- 帰納法の仮定から m には素因数が存在するので，
-      specialize ih m mltn mgt2
-      
-      -- その素因数を p とする.
-      obtain ⟨p, pp, pdvd⟩ := ih
-      
-      -- その素数 p が望みの性質を満たす．
-      use p, pp
-      trans m <;> assumption
+    -- 帰納法の仮定から m には素因数が存在するので，
+    have ih := exists_prime_factor mgt2
+    
+    -- その素因数を p とする.
+    obtain ⟨p, pp, pdvd⟩ := ih
+    
+    -- その素数 p が望みの性質を満たす．
+    use p, pp
+    trans m <;> assumption
 
 theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   intro n

--- a/Lean4Textbook/PrimeInfinite.lean
+++ b/Lean4Textbook/PrimeInfinite.lean
@@ -68,14 +68,13 @@ theorem primes_infinite : ∀ n, ∃ p, n < p ∧ Nat.Prime p := by
   set k := (n + 1).factorial + 1 with kh
 
   -- このとき k はもちろん 2 以上であるので，
-  have : 2 ≤ k := calc
+  have ge2 : 2 ≤ k := calc
     2 ≤ n + 1 + 1 := by simp_arith 
     _ ≤ (n + 1).factorial + 1 := by gcongr; apply Nat.self_le_factorial
     _ = k := by rw [← kh]
 
   -- 先に示した定理により， k には素因数 p が存在する.
-  obtain ⟨p, pp, pdvd⟩ := exists_prime_factor this
-  clear this
+  obtain ⟨p, pp, pdvd⟩ := exists_prime_factor ge2
 
   -- この p が望みの性質を満たすことを示そう．
   refine ⟨p, ?_, pp⟩


### PR DESCRIPTION
## 変更点まとめ

### 全般

* コメントをつけました．コメントを追うだけで，自然言語による証明が思い出せるようにしてあります．

### two_le

* 前半の場合分けのネストをなくしました．
* show を使ってゴールを見やすくしました

### exists_prime_factor

* induction タクティクは不要なので消しました
* n と m の両方に対して素数かどうかで場合分けを行っていましたが，n に対するものだけで十分なので m に対する場合分けの方は削除しました．

### primes_infinite

* calc を使用している個所を整理しました
* せっかくなので階乗の記法を導入しました．見栄えがいいので，いいんじゃないでしょうか．